### PR TITLE
在 sn 达到 65535 之后重置

### DIFF
--- a/src/MessageSource/MessageSource.ts
+++ b/src/MessageSource/MessageSource.ts
@@ -26,6 +26,7 @@ export class MessageSource extends EventEmitter implements MessageSource {
   protected onEventArrive(packet: KHEventPacket): void {
     if ((packet as KHEventPacket).sn === this.sn + 1) {
       this.sn += 1
+      if (this.sn >= 65535) this.sn = 0;
       this.emit('message', cloneDeep(packet.d))
       this.eventProcess(packet)
       this.buffer.sort((a, b) => a.sn - b.sn)


### PR DESCRIPTION
机器人接受到的消息 sn 在达到 65535 时，下一个消息事件所携带的 sn 为 1，此时若不重置 sn 为 0，后面收到的消息全部都会被丢弃